### PR TITLE
testnet hedera deploy and interact scripts

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -69,3 +69,51 @@ To modify or extend the contracts:
 2. Update or add tests in the `test` directory as needed.
 3. Run `npx hardhat compile` to compile your changes.
 4. Run the tests to ensure everything is working as expected.
+
+## Hedera
+
+To view your contract on the Hedera Testnet explorer:
+
+https://hashscan.io/testnet
+
+Test Hedera Connection:
+
+`node test-connection.js`
+
+Compile the contracts:
+
+`npx hardhat compile`
+
+Run the tests:
+
+`npx hardhat test`
+
+Deploy the contracts to Hedera testnet:
+
+`npx hardhat run scripts/deploy.js --network hedera`
+
+Interact with the deployed contracts:
+
+`npx hardhat run scripts/interact.js --network hedera`
+
+Replace the placeholder contract addresses (nzDollarAddress and vaultAddress) with your actual deployed contract addresses.
+
+---
+
+Create a Hedera Testnet Account:
+
+1. Go to the Hedera Portal: https://portal.hedera.com/
+2. Click on "Get started with testnet"
+3. Sign up for an account if you don't have one
+
+
+Access Your Testnet Account:
+
+1. After logging in, go to "Access testnet account"
+2. You'll see your Account ID and Private Key
+
+---
+
+Use the Hedera Token Service (HTS) instead of the custom ERC20 token for better integration with Hedera's native features.
+
+Use the Hedera Consensus Service (HCS) for additional features like timestamping or audit trails.

--- a/contracts/hardhat.config.js
+++ b/contracts/hardhat.config.js
@@ -1,10 +1,13 @@
 require("@nomicfoundation/hardhat-toolbox");
+require('dotenv').config();
 
 module.exports = {
   solidity: "0.8.19",
   networks: {
-    hardhat: {
-      chainId: 1337
-    }
-  }
+    hedera: {
+      url: `https://${process.env.HEDERA_NETWORK}.hashio.io/api`,
+      accounts: [`0x${process.env.HEDERA_PRIVATE_KEY}`],
+      chainId: process.env.HEDERA_NETWORK === 'testnet' ? 296 : 295,
+    },
+  },
 };

--- a/contracts/package-lock.json
+++ b/contracts/package-lock.json
@@ -8,10 +8,12 @@
             "name": "skeuomorphia-contracts",
             "version": "1.0.0",
             "dependencies": {
+                "@hashgraph/sdk": "^2.19.2",
                 "@openzeppelin/contracts": "^4.8.0"
             },
             "devDependencies": {
                 "@nomicfoundation/hardhat-toolbox": "^2.0.0",
+                "dotenv": "^16.0.3",
                 "hardhat": "^2.14.0"
             }
         },
@@ -91,7 +93,6 @@
             "version": "5.7.0",
             "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.7.0.tgz",
             "integrity": "sha512-351ktp42TiRcYB3H1OP8yajPeAQstMW/yCFokj/AthP9bLHzQFPlOrxOcwYEDkUAICmOHljvN4K39OMTMUa9RA==",
-            "dev": true,
             "funding": [
                 {
                     "type": "individual",
@@ -119,7 +120,6 @@
             "version": "5.7.0",
             "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.7.0.tgz",
             "integrity": "sha512-R41c9UkchKCpAqStMYUpdunjo3pkEvZC3FAwZn5S5MGbXoMQOHIdHItezTETxAO5bevtMApSyEhn9+CHcDsWBw==",
-            "dev": true,
             "funding": [
                 {
                     "type": "individual",
@@ -145,7 +145,6 @@
             "version": "5.7.0",
             "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.7.0.tgz",
             "integrity": "sha512-a16V8bq1/Cz+TGCkE2OPMTOUDLS3grCpdjoJCYNnVBbdYEMSgKrU0+B90s8b6H+ByYTBZN7a3g76jdIJi7UfKQ==",
-            "dev": true,
             "funding": [
                 {
                     "type": "individual",
@@ -169,7 +168,6 @@
             "version": "5.7.0",
             "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.7.0.tgz",
             "integrity": "sha512-9wYhYt7aghVGo758POM5nqcOMaE168Q6aRLJZwUmiqSrAungkG74gSSeKEIR7ukixesdRZGPgVqme6vmxs1fkA==",
-            "dev": true,
             "funding": [
                 {
                     "type": "individual",
@@ -193,7 +191,6 @@
             "version": "5.7.0",
             "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.7.0.tgz",
             "integrity": "sha512-Dr8tcHt2mEbsZr/mwTPIQAf3Ai0Bks/7gTw9dSqk1mQvhW3XvRlmDJr/4n+wg1JmCl16NZue17CDh8xb/vZ0sQ==",
-            "dev": true,
             "funding": [
                 {
                     "type": "individual",
@@ -235,7 +232,6 @@
             "version": "5.7.0",
             "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.7.0.tgz",
             "integrity": "sha512-n1CAdIHRWjSucQO3MC1zPSVgV/6dy/fjL9pMrPP9peL+QxEg9wOsVqwD4+818B6LUEtaXzVHQiuivzRoxPxUGw==",
-            "dev": true,
             "funding": [
                 {
                     "type": "individual",
@@ -257,7 +253,6 @@
             "version": "5.7.0",
             "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.7.0.tgz",
             "integrity": "sha512-nsbxwgFXWh9NyYWo+U8atvmMsSdKJprTcICAkvbBffT75qDocbuggBU0SJiVK2MuTrp0q+xvLkTnGMPK1+uA9A==",
-            "dev": true,
             "funding": [
                 {
                     "type": "individual",
@@ -277,7 +272,6 @@
             "version": "5.7.0",
             "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.7.0.tgz",
             "integrity": "sha512-DHI+y5dBNvkpYUMiRQyxRBYBefZkJfo70VUkUAsRjcPs47muV9evftfZ0PJVCXYbAiCgght0DtcF9srFQmIgWA==",
-            "dev": true,
             "funding": [
                 {
                     "type": "individual",
@@ -327,7 +321,6 @@
             "version": "5.7.0",
             "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.7.0.tgz",
             "integrity": "sha512-qX5WrQfnah1EFnO5zJv1v46a8HW0+E5xuBBDTwMFZLuVTx0tbU2kkx15NqdjxecrLGatQN9FGQKpb1FKdHCt+g==",
-            "dev": true,
             "funding": [
                 {
                     "type": "individual",
@@ -420,7 +413,6 @@
             "version": "5.7.0",
             "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.7.0.tgz",
             "integrity": "sha512-2UcPboeL/iW+pSg6vZ6ydF8tCnv3Iu/8tUmLLzWWGzxWKFFqOBQFLo6uLUv6BDrLgCDfN28RJ/wtByx+jZ4KBg==",
-            "dev": true,
             "funding": [
                 {
                     "type": "individual",
@@ -441,7 +433,6 @@
             "version": "5.7.0",
             "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.7.0.tgz",
             "integrity": "sha512-0odtFdXu/XHtjQXJYA3u9G0G8btm0ND5Cu8M7i5vhEcE8/HmF4Lbdqanwyv4uQTr2tx6b7fQRmgLrsnpQlmnig==",
-            "dev": true,
             "funding": [
                 {
                     "type": "individual",
@@ -458,7 +449,6 @@
             "version": "5.7.1",
             "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.7.1.tgz",
             "integrity": "sha512-n/MufjFYv3yFcUyfhnXotyDlNdFb7onmkSy8aQERi2PjNcnWQ66xXxa3XlS8nCcA8aJKJjIIMNJTC7tu80GwpQ==",
-            "dev": true,
             "funding": [
                 {
                     "type": "individual",
@@ -500,7 +490,6 @@
             "version": "5.7.0",
             "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.7.0.tgz",
             "integrity": "sha512-J87jy8suntrAkIZtecpxEPxY//szqr1mlBaYlQ0r4RCaiD2hjheqF9s1LVE8vVuJCXisjIP+JgtK/Do54ej4Sw==",
-            "dev": true,
             "funding": [
                 {
                     "type": "individual",
@@ -582,7 +571,6 @@
             "version": "5.7.0",
             "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.7.0.tgz",
             "integrity": "sha512-rBxzX2vK8mVF7b0Tol44t5Tb8gomOHkj5guL+HhzQ1yBh/ydjGnpw6at+X6Iw0Kp3OzzzkcKp8N9r0W4kYSs9w==",
-            "dev": true,
             "funding": [
                 {
                     "type": "individual",
@@ -626,7 +614,6 @@
             "version": "5.7.0",
             "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.7.0.tgz",
             "integrity": "sha512-MZdy2nL3wO0u7gkB4nA/pEf8lu1TlFswPNmy8AiYkfKTdO6eXBJyUdmHO/ehm/htHw9K/qF8ujnTyUAD+Ry54Q==",
-            "dev": true,
             "funding": [
                 {
                     "type": "individual",
@@ -677,7 +664,6 @@
             "version": "5.7.0",
             "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.7.0.tgz",
             "integrity": "sha512-/9nu+lj0YswRNSH0NXYqrh8775XNyEdUQAuf3f+SmOrnVewcJ5SBNAjF7lpgehKi4abvNNXyf+HX86czCdJ8Mg==",
-            "dev": true,
             "funding": [
                 {
                     "type": "individual",
@@ -699,7 +685,6 @@
             "version": "5.7.0",
             "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.7.0.tgz",
             "integrity": "sha512-kmcNicCp1lp8qanMTC3RIikGgoJ80ztTyvtsFvCYpSCfkjhD0jZ2LOrnbcuxuToLIUYYf+4XwD1rP+B/erDIhQ==",
-            "dev": true,
             "funding": [
                 {
                     "type": "individual",
@@ -785,7 +770,6 @@
             "version": "5.7.1",
             "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.7.1.tgz",
             "integrity": "sha512-Gueu8lSvyjBWL4cYsWsjh6MtMwM0+H4HvqFPZfB6dV8ctbP9zFAO73VG1cMWae0FLPCtz0peKPpZY8/ugJJX2w==",
-            "dev": true,
             "funding": [
                 {
                     "type": "individual",
@@ -838,6 +822,172 @@
             "license": "MIT",
             "engines": {
                 "node": ">=14"
+            }
+        },
+        "node_modules/@grpc/grpc-js": {
+            "version": "1.8.2",
+            "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.8.2.tgz",
+            "integrity": "sha512-5cqCjUvDKJWHGeu1prlrFOUmjuML0NequZKJ38PsCkfwIqPnZq4Q9burPP3It7/+46wpl0KsqVN3s6Te3B9Qtw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@grpc/proto-loader": "^0.7.0",
+                "@types/node": ">=12.12.47"
+            },
+            "engines": {
+                "node": "^8.13.0 || >=10.10.0"
+            }
+        },
+        "node_modules/@grpc/proto-loader": {
+            "version": "0.7.13",
+            "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.13.tgz",
+            "integrity": "sha512-AiXO/bfe9bmxBjxxtYxFAXGZvMaN5s8kO+jBHAJCON8rJoB5YS/D6X7ZNc6XQkuHNmyl4CYaMI1fJ/Gn27RGGw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "lodash.camelcase": "^4.3.0",
+                "long": "^5.0.0",
+                "protobufjs": "^7.2.5",
+                "yargs": "^17.7.2"
+            },
+            "bin": {
+                "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/@grpc/proto-loader/node_modules/cliui": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+            "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+            "license": "ISC",
+            "dependencies": {
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.1",
+                "wrap-ansi": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@grpc/proto-loader/node_modules/long": {
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+            "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==",
+            "license": "Apache-2.0"
+        },
+        "node_modules/@grpc/proto-loader/node_modules/yargs": {
+            "version": "17.7.2",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+            "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+            "license": "MIT",
+            "dependencies": {
+                "cliui": "^8.0.1",
+                "escalade": "^3.1.1",
+                "get-caller-file": "^2.0.5",
+                "require-directory": "^2.1.1",
+                "string-width": "^4.2.3",
+                "y18n": "^5.0.5",
+                "yargs-parser": "^21.1.1"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@grpc/proto-loader/node_modules/yargs-parser": {
+            "version": "21.1.1",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+            "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@hashgraph/cryptography": {
+            "version": "1.4.8-beta.7",
+            "resolved": "https://registry.npmjs.org/@hashgraph/cryptography/-/cryptography-1.4.8-beta.7.tgz",
+            "integrity": "sha512-FoffVo/UdhkqQUhbh/G+0lcmBYexvVs/RQqilyhzCuNzPB9lRWrJmKPT1pesFoWVC6j3kbbFcWezr9xbm9WrUA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "asn1js": "^3.0.5",
+                "bignumber.js": "^9.1.1",
+                "bn.js": "^5.2.1",
+                "buffer": "^6.0.3",
+                "crypto-js": "^4.2.0",
+                "elliptic": "^6.5.4",
+                "js-base64": "^3.7.4",
+                "node-forge": "^1.3.1",
+                "spark-md5": "^3.0.2",
+                "tweetnacl": "^1.0.3",
+                "utf8": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "peerDependencies": {
+                "expo": "^49.0.16",
+                "expo-crypto": "^10.1.2",
+                "expo-random": "^12.1.2"
+            },
+            "peerDependenciesMeta": {
+                "expo": {
+                    "optional": true
+                },
+                "expo-crypto": {
+                    "optional": true
+                },
+                "expo-random": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@hashgraph/proto": {
+            "version": "2.15.0-beta.3",
+            "resolved": "https://registry.npmjs.org/@hashgraph/proto/-/proto-2.15.0-beta.3.tgz",
+            "integrity": "sha512-/95cydqBQRaO1gagBOenNpcfJIcnRx+vzefhuzSFNp4pfl0AM3oXau39hM2raKLhFHoKZysSjkXkMp24AaCE5w==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "long": "^4.0.0",
+                "protobufjs": "^7.2.5"
+            },
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
+        "node_modules/@hashgraph/sdk": {
+            "version": "2.50.0",
+            "resolved": "https://registry.npmjs.org/@hashgraph/sdk/-/sdk-2.50.0.tgz",
+            "integrity": "sha512-TsklSXxXpyinVo4hOENOtm4e1jgYALeY8S8W+0SlMlbya/azzW0UZcJuriRElFGZhFzE1uqFTc7cN0ZMP059mQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@ethersproject/abi": "^5.7.0",
+                "@ethersproject/bignumber": "^5.7.0",
+                "@ethersproject/bytes": "^5.7.0",
+                "@ethersproject/rlp": "^5.7.0",
+                "@grpc/grpc-js": "1.8.2",
+                "@hashgraph/cryptography": "1.4.8-beta.7",
+                "@hashgraph/proto": "2.15.0-beta.3",
+                "axios": "^1.6.4",
+                "bignumber.js": "^9.1.1",
+                "bn.js": "^5.1.1",
+                "crypto-js": "^4.2.0",
+                "js-base64": "^3.7.4",
+                "long": "^4.0.0",
+                "pino": "^8.14.1",
+                "pino-pretty": "^10.0.0",
+                "protobufjs": "^7.2.5",
+                "rfc4648": "^1.5.3",
+                "utf8": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "expo": "^49.0.16"
+            },
+            "peerDependenciesMeta": {
+                "expo": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@jridgewell/resolve-uri": {
@@ -1376,6 +1526,70 @@
             "integrity": "sha512-xSmezSupL+y9VkHZJGDoCBpmnB2ogM13ccaYDWqJTfS3dbuHkgjuwDFUmaFauBCboQMGB/S5UqUl2y54X99BmA==",
             "license": "MIT"
         },
+        "node_modules/@protobufjs/aspromise": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+            "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/@protobufjs/base64": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+            "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/@protobufjs/codegen": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+            "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/@protobufjs/eventemitter": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+            "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/@protobufjs/fetch": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+            "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@protobufjs/aspromise": "^1.1.1",
+                "@protobufjs/inquire": "^1.1.0"
+            }
+        },
+        "node_modules/@protobufjs/float": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+            "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/@protobufjs/inquire": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+            "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/@protobufjs/path": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+            "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/@protobufjs/pool": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+            "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/@protobufjs/utf8": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+            "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+            "license": "BSD-3-Clause"
+        },
         "node_modules/@scure/base": {
             "version": "1.1.8",
             "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.8.tgz",
@@ -1767,7 +1981,6 @@
             "version": "22.5.3",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.3.tgz",
             "integrity": "sha512-njripolh85IA9SQGTAqbmnNZTdxv7X/4OYGPz8tgy5JDr8MP+uDBa921GpYEoDDnwm0Hmn5ZPeJgiiSTPoOzkQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "undici-types": "~6.19.2"
@@ -1816,6 +2029,18 @@
             "dev": true,
             "license": "ISC",
             "peer": true
+        },
+        "node_modules/abort-controller": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+            "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+            "license": "MIT",
+            "dependencies": {
+                "event-target-shim": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=6.5"
+            }
         },
         "node_modules/acorn": {
             "version": "8.12.1",
@@ -1960,7 +2185,6 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
             "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -2057,6 +2281,26 @@
             "license": "MIT",
             "peer": true
         },
+        "node_modules/asn1js": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.5.tgz",
+            "integrity": "sha512-FVnvrKJwpt9LP2lAMl8qZswRNm3T4q9CON+bxldk2iwk3FFpuwhx2FfinyitizWHsVYyaY+y5JzDR0rCMV5yTQ==",
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "pvtsutils": "^1.3.2",
+                "pvutils": "^1.1.3",
+                "tslib": "^2.4.0"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
+        "node_modules/asn1js/node_modules/tslib": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+            "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+            "license": "0BSD"
+        },
         "node_modules/assertion-error": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -2091,9 +2335,7 @@
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
             "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/at-least-node": {
             "version": "1.0.0",
@@ -2106,13 +2348,20 @@
                 "node": ">= 4.0.0"
             }
         },
+        "node_modules/atomic-sleep": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+            "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
         "node_modules/axios": {
             "version": "1.7.7",
             "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
             "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
-            "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "follow-redirects": "^1.15.6",
                 "form-data": "^4.0.0",
@@ -2136,6 +2385,26 @@
                 "safe-buffer": "^5.0.1"
             }
         },
+        "node_modules/base64-js": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
+        },
         "node_modules/bech32": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
@@ -2143,6 +2412,15 @@
             "dev": true,
             "license": "MIT",
             "peer": true
+        },
+        "node_modules/bignumber.js": {
+            "version": "9.1.2",
+            "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
+            "integrity": "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==",
+            "license": "MIT",
+            "engines": {
+                "node": "*"
+            }
         },
         "node_modules/binary-extensions": {
             "version": "2.3.0",
@@ -2168,7 +2446,6 @@
             "version": "5.2.1",
             "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
             "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/boxen": {
@@ -2311,7 +2588,6 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
             "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/browser-stdout": {
@@ -2356,6 +2632,30 @@
                 "bs58": "^4.0.0",
                 "create-hash": "^1.1.0",
                 "safe-buffer": "^5.1.2"
+            }
+        },
+        "node_modules/buffer": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+            "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "base64-js": "^1.3.1",
+                "ieee754": "^1.2.1"
             }
         },
         "node_modules/buffer-from": {
@@ -2676,6 +2976,12 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/colorette": {
+            "version": "2.0.20",
+            "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+            "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+            "license": "MIT"
+        },
         "node_modules/colors": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
@@ -2691,9 +2997,7 @@
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
             "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-            "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "delayed-stream": "~1.0.0"
             },
@@ -2900,6 +3204,21 @@
                 "node": "*"
             }
         },
+        "node_modules/crypto-js": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+            "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
+            "license": "MIT"
+        },
+        "node_modules/dateformat": {
+            "version": "4.6.3",
+            "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+            "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+            "license": "MIT",
+            "engines": {
+                "node": "*"
+            }
+        },
         "node_modules/death": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/death/-/death-1.1.0.tgz",
@@ -2994,9 +3313,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
             "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-            "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=0.4.0"
             }
@@ -3048,11 +3365,23 @@
                 "node": ">=8"
             }
         },
+        "node_modules/dotenv": {
+            "version": "16.4.5",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+            "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://dotenvx.com"
+            }
+        },
         "node_modules/elliptic": {
             "version": "6.5.4",
             "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
             "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "bn.js": "^4.11.9",
@@ -3068,15 +3397,22 @@
             "version": "4.12.0",
             "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
             "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/emoji-regex": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
             "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-            "dev": true,
             "license": "MIT"
+        },
+        "node_modules/end-of-stream": {
+            "version": "1.4.4",
+            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+            "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+            "license": "MIT",
+            "dependencies": {
+                "once": "^1.4.0"
+            }
         },
         "node_modules/enquirer": {
             "version": "2.4.1",
@@ -3131,7 +3467,6 @@
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
             "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6"
@@ -3489,6 +3824,24 @@
                 "npm": ">=3"
             }
         },
+        "node_modules/event-target-shim": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+            "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/events": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+            "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.8.x"
+            }
+        },
         "node_modules/evp_bytestokey": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
@@ -3499,6 +3852,12 @@
                 "md5.js": "^1.3.4",
                 "safe-buffer": "^5.1.1"
             }
+        },
+        "node_modules/fast-copy": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.2.tgz",
+            "integrity": "sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ==",
+            "license": "MIT"
         },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
@@ -3533,6 +3892,21 @@
             "dev": true,
             "license": "MIT",
             "peer": true
+        },
+        "node_modules/fast-redact": {
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.5.0.tgz",
+            "integrity": "sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/fast-safe-stringify": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+            "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+            "license": "MIT"
         },
         "node_modules/fast-uri": {
             "version": "3.0.1",
@@ -3607,7 +3981,6 @@
             "version": "1.15.8",
             "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.8.tgz",
             "integrity": "sha512-xgrmBhBToVKay1q2Tao5LI26B83UhrB/vM1avwVSDzt8rx3rO6AizBAaF46EgksTVr+rFTQaqZZ9MVBfUe4nig==",
-            "dev": true,
             "funding": [
                 {
                     "type": "individual",
@@ -3628,9 +4001,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
             "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-            "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
@@ -3707,7 +4078,6 @@
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
             "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": "6.* || 8.* || >= 10.*"
@@ -4127,7 +4497,6 @@
             "version": "1.1.7",
             "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
             "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "inherits": "^2.0.3",
@@ -4166,11 +4535,16 @@
             "license": "MIT",
             "peer": true
         },
+        "node_modules/help-me": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
+            "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
+            "license": "MIT"
+        },
         "node_modules/hmac-drbg": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
             "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "hash.js": "^1.0.3",
@@ -4258,6 +4632,26 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/ieee754": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "BSD-3-Clause"
+        },
         "node_modules/ignore": {
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -4302,7 +4696,6 @@
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-            "dev": true,
             "license": "ISC"
         },
         "node_modules/ini": {
@@ -4361,7 +4754,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
             "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -4440,11 +4832,25 @@
             "license": "ISC",
             "peer": true
         },
+        "node_modules/joycon": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+            "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/js-base64": {
+            "version": "3.7.7",
+            "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.7.tgz",
+            "integrity": "sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw==",
+            "license": "BSD-3-Clause"
+        },
         "node_modules/js-sha3": {
             "version": "0.8.0",
             "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
             "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/js-yaml": {
@@ -4556,9 +4962,7 @@
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
             "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/lodash.truncate": {
             "version": "4.4.2",
@@ -4661,6 +5065,12 @@
                 "node": ">=8"
             }
         },
+        "node_modules/long": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+            "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+            "license": "Apache-2.0"
+        },
         "node_modules/loupe": {
             "version": "2.3.7",
             "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
@@ -4754,9 +5164,7 @@
             "version": "1.52.0",
             "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
             "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-            "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">= 0.6"
             }
@@ -4765,9 +5173,7 @@
             "version": "2.1.35",
             "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
             "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-            "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "mime-db": "1.52.0"
             },
@@ -4779,14 +5185,12 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
             "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
-            "dev": true,
             "license": "ISC"
         },
         "node_modules/minimalistic-crypto-utils": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
             "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/minimatch": {
@@ -4806,9 +5210,7 @@
             "version": "1.2.8",
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
             "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-            "dev": true,
             "license": "MIT",
-            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -5071,6 +5473,15 @@
                 "lodash": "^4.17.21"
             }
         },
+        "node_modules/node-forge": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+            "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+            "license": "(BSD-3-Clause OR GPL-2.0)",
+            "engines": {
+                "node": ">= 6.13.0"
+            }
+        },
         "node_modules/node-gyp-build": {
             "version": "4.8.2",
             "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.2.tgz",
@@ -5174,11 +5585,19 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/on-exit-leak-free": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+            "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
         "node_modules/once": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "wrappy": "1"
@@ -5370,6 +5789,101 @@
                 "node": ">=6"
             }
         },
+        "node_modules/pino": {
+            "version": "8.21.0",
+            "resolved": "https://registry.npmjs.org/pino/-/pino-8.21.0.tgz",
+            "integrity": "sha512-ip4qdzjkAyDDZklUaZkcRFb2iA118H9SgRh8yzTkSQK8HilsOJF7rSY8HoW5+I0M46AZgX/pxbprf2vvzQCE0Q==",
+            "license": "MIT",
+            "dependencies": {
+                "atomic-sleep": "^1.0.0",
+                "fast-redact": "^3.1.1",
+                "on-exit-leak-free": "^2.1.0",
+                "pino-abstract-transport": "^1.2.0",
+                "pino-std-serializers": "^6.0.0",
+                "process-warning": "^3.0.0",
+                "quick-format-unescaped": "^4.0.3",
+                "real-require": "^0.2.0",
+                "safe-stable-stringify": "^2.3.1",
+                "sonic-boom": "^3.7.0",
+                "thread-stream": "^2.6.0"
+            },
+            "bin": {
+                "pino": "bin.js"
+            }
+        },
+        "node_modules/pino-abstract-transport": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.2.0.tgz",
+            "integrity": "sha512-Guhh8EZfPCfH+PMXAb6rKOjGQEoy0xlAIn+irODG5kgfYV+BQ0rGYYWTIel3P5mmyXqkYkPmdIkywsn6QKUR1Q==",
+            "license": "MIT",
+            "dependencies": {
+                "readable-stream": "^4.0.0",
+                "split2": "^4.0.0"
+            }
+        },
+        "node_modules/pino-abstract-transport/node_modules/readable-stream": {
+            "version": "4.5.2",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
+            "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
+            "license": "MIT",
+            "dependencies": {
+                "abort-controller": "^3.0.0",
+                "buffer": "^6.0.3",
+                "events": "^3.3.0",
+                "process": "^0.11.10",
+                "string_decoder": "^1.3.0"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            }
+        },
+        "node_modules/pino-pretty": {
+            "version": "10.3.1",
+            "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-10.3.1.tgz",
+            "integrity": "sha512-az8JbIYeN/1iLj2t0jR9DV48/LQ3RC6hZPpapKPkb84Q+yTidMCpgWxIT3N0flnBDilyBQ1luWNpOeJptjdp/g==",
+            "license": "MIT",
+            "dependencies": {
+                "colorette": "^2.0.7",
+                "dateformat": "^4.6.3",
+                "fast-copy": "^3.0.0",
+                "fast-safe-stringify": "^2.1.1",
+                "help-me": "^5.0.0",
+                "joycon": "^3.1.1",
+                "minimist": "^1.2.6",
+                "on-exit-leak-free": "^2.1.0",
+                "pino-abstract-transport": "^1.0.0",
+                "pump": "^3.0.0",
+                "readable-stream": "^4.0.0",
+                "secure-json-parse": "^2.4.0",
+                "sonic-boom": "^3.0.0",
+                "strip-json-comments": "^3.1.1"
+            },
+            "bin": {
+                "pino-pretty": "bin.js"
+            }
+        },
+        "node_modules/pino-pretty/node_modules/readable-stream": {
+            "version": "4.5.2",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
+            "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
+            "license": "MIT",
+            "dependencies": {
+                "abort-controller": "^3.0.0",
+                "buffer": "^6.0.3",
+                "events": "^3.3.0",
+                "process": "^0.11.10",
+                "string_decoder": "^1.3.0"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            }
+        },
+        "node_modules/pino-std-serializers": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.2.2.tgz",
+            "integrity": "sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA==",
+            "license": "MIT"
+        },
         "node_modules/prelude-ls": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -5397,6 +5911,15 @@
                 "url": "https://github.com/prettier/prettier?sponsor=1"
             }
         },
+        "node_modules/process": {
+            "version": "0.11.10",
+            "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+            "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6.0"
+            }
+        },
         "node_modules/process-nextick-args": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -5404,6 +5927,12 @@
             "dev": true,
             "license": "MIT",
             "peer": true
+        },
+        "node_modules/process-warning": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-3.0.0.tgz",
+            "integrity": "sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ==",
+            "license": "MIT"
         },
         "node_modules/promise": {
             "version": "8.3.0",
@@ -5416,13 +5945,75 @@
                 "asap": "~2.0.6"
             }
         },
+        "node_modules/protobufjs": {
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
+            "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
+            "hasInstallScript": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@protobufjs/aspromise": "^1.1.2",
+                "@protobufjs/base64": "^1.1.2",
+                "@protobufjs/codegen": "^2.0.4",
+                "@protobufjs/eventemitter": "^1.1.0",
+                "@protobufjs/fetch": "^1.1.0",
+                "@protobufjs/float": "^1.0.2",
+                "@protobufjs/inquire": "^1.1.0",
+                "@protobufjs/path": "^1.1.2",
+                "@protobufjs/pool": "^1.1.0",
+                "@protobufjs/utf8": "^1.1.0",
+                "@types/node": ">=13.7.0",
+                "long": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
+        "node_modules/protobufjs/node_modules/long": {
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+            "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==",
+            "license": "Apache-2.0"
+        },
         "node_modules/proxy-from-env": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
             "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/pump": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+            "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
             "license": "MIT",
-            "peer": true
+            "dependencies": {
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
+            }
+        },
+        "node_modules/pvtsutils": {
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.5.tgz",
+            "integrity": "sha512-ARvb14YB9Nm2Xi6nBq1ZX6dAM0FsJnuk+31aUp4TrcZEdKUlSqOqsxJHUPJDNE3qiIp+iUPEIeR6Je/tgV7zsA==",
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^2.6.1"
+            }
+        },
+        "node_modules/pvtsutils/node_modules/tslib": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+            "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+            "license": "0BSD"
+        },
+        "node_modules/pvutils": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.3.tgz",
+            "integrity": "sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.0.0"
+            }
         },
         "node_modules/qs": {
             "version": "6.13.0",
@@ -5462,6 +6053,12 @@
             ],
             "license": "MIT",
             "peer": true
+        },
+        "node_modules/quick-format-unescaped": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+            "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+            "license": "MIT"
         },
         "node_modules/randombytes": {
             "version": "2.1.0",
@@ -5515,6 +6112,15 @@
             },
             "engines": {
                 "node": ">=8.10.0"
+            }
+        },
+        "node_modules/real-require": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+            "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 12.13.0"
             }
         },
         "node_modules/rechoir": {
@@ -5587,7 +6193,6 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
             "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -5639,6 +6244,12 @@
                 "iojs": ">=1.0.0",
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/rfc4648": {
+            "version": "1.5.3",
+            "resolved": "https://registry.npmjs.org/rfc4648/-/rfc4648-1.5.3.tgz",
+            "integrity": "sha512-MjOWxM065+WswwnmNONOT+bD1nXzY9Km6u3kzvnx8F8/HXGZdz3T6e6vZJ8Q/RIMUSp/nxqjH3GwvJDy8ijeQQ==",
+            "license": "MIT"
         },
         "node_modules/ripemd160": {
             "version": "2.0.2",
@@ -5693,7 +6304,6 @@
             "version": "5.2.1",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
             "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -5709,6 +6319,15 @@
                 }
             ],
             "license": "MIT"
+        },
+        "node_modules/safe-stable-stringify": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+            "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            }
         },
         "node_modules/safer-buffer": {
             "version": "2.1.2",
@@ -5859,6 +6478,12 @@
             "engines": {
                 "node": ">=10.0.0"
             }
+        },
+        "node_modules/secure-json-parse": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
+            "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==",
+            "license": "BSD-3-Clause"
         },
         "node_modules/semver": {
             "version": "6.3.1",
@@ -6155,6 +6780,15 @@
                 "node": ">=10"
             }
         },
+        "node_modules/sonic-boom": {
+            "version": "3.8.1",
+            "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.8.1.tgz",
+            "integrity": "sha512-y4Z8LCDBuum+PBP3lSV7RHrXscqksve/bi0as7mhwVnBW+/wUqKT/2Kb7um8yqcFy0duYbbPxzt89Zy2nOCaxg==",
+            "license": "MIT",
+            "dependencies": {
+                "atomic-sleep": "^1.0.0"
+            }
+        },
         "node_modules/source-map": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
@@ -6188,6 +6822,21 @@
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/spark-md5": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/spark-md5/-/spark-md5-3.0.2.tgz",
+            "integrity": "sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw==",
+            "license": "(WTFPL OR MIT)"
+        },
+        "node_modules/split2": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+            "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+            "license": "ISC",
+            "engines": {
+                "node": ">= 10.x"
             }
         },
         "node_modules/sprintf-js": {
@@ -6235,7 +6884,6 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
             "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "safe-buffer": "~5.2.0"
@@ -6253,7 +6901,6 @@
             "version": "4.2.3",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
             "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "emoji-regex": "^8.0.0",
@@ -6268,7 +6915,6 @@
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
             "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ansi-regex": "^5.0.1"
@@ -6295,7 +6941,6 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
             "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -6447,6 +7092,15 @@
             },
             "engines": {
                 "node": ">= 0.12"
+            }
+        },
+        "node_modules/thread-stream": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.7.0.tgz",
+            "integrity": "sha512-qQiRWsU/wvNolI6tbbCKd9iKaTnCXsTwVxhhKM6nctPdujTyztjlbUkUTUymidWcMnZ5pWR0ej4a0tjsW021vw==",
+            "license": "MIT",
+            "dependencies": {
+                "real-require": "^0.2.0"
             }
         },
         "node_modules/tmp": {
@@ -6669,7 +7323,6 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
             "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
-            "dev": true,
             "license": "Unlicense"
         },
         "node_modules/tweetnacl-util": {
@@ -6846,7 +7499,6 @@
             "version": "6.19.8",
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
             "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/universalify": {
@@ -6873,9 +7525,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
             "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/util-deprecate": {
             "version": "1.0.2",
@@ -7034,7 +7684,6 @@
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
             "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ansi-styles": "^4.0.0",
@@ -7052,7 +7701,6 @@
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
             "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "color-convert": "^2.0.1"
@@ -7068,7 +7716,6 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
             "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "color-name": "~1.1.4"
@@ -7081,14 +7728,12 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-            "dev": true,
             "license": "ISC"
         },
         "node_modules/ws": {
@@ -7117,7 +7762,6 @@
             "version": "5.0.8",
             "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
             "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": ">=10"

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -4,13 +4,17 @@
     "description": "Smart contracts for banknote collateral vault",
     "main": "index.js",
     "scripts": {
-      "test": "npx hardhat test"
+      "test": "npx hardhat test",
+      "deploy": "npx hardhat run scripts/deploy.js --network hedera",
+      "run": "npx hardhat run scripts/interact.js --network hedera"
     },
     "devDependencies": {
       "@nomicfoundation/hardhat-toolbox": "^2.0.0",
+      "dotenv": "^16.0.3",
       "hardhat": "^2.14.0"
     },
     "dependencies": {
+      "@hashgraph/sdk": "^2.19.2",
       "@openzeppelin/contracts": "^4.8.0"
     }
   }

--- a/contracts/scripts/deploy.js
+++ b/contracts/scripts/deploy.js
@@ -1,0 +1,26 @@
+const { ethers } = require("hardhat");
+
+async function main() {
+  const [deployer] = await ethers.getSigners();
+
+  console.log("Deploying contracts with the account:", deployer.address);
+
+  const NZDollar = await ethers.getContractFactory("NZDollar");
+  const nzDollar = await NZDollar.deploy(ethers.utils.parseEther("1000000"));
+  await nzDollar.deployed();
+
+  console.log("NZDollar deployed to:", nzDollar.address);
+
+  const BanknoteCollateralVault = await ethers.getContractFactory("BanknoteCollateralVault");
+  const vault = await BanknoteCollateralVault.deploy(deployer.address);
+  await vault.deployed();
+
+  console.log("BanknoteCollateralVault deployed to:", vault.address);
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/contracts/scripts/interact.js
+++ b/contracts/scripts/interact.js
@@ -1,0 +1,95 @@
+// scripts/interact.js
+const { ethers } = require("hardhat");
+const fs = require('fs');
+
+// Setup logging
+const logFile = 'interaction_log.txt';
+function log(message) {
+  const timestamp = new Date().toISOString();
+  const logMessage = `${timestamp}: ${message}\n`;
+  console.log(logMessage);
+  fs.appendFileSync(logFile, logMessage);
+}
+
+async function main() {
+  try {
+    const [signer, addr1] = await ethers.getSigners();
+
+    log(`Using signer address: ${signer.address}`);
+
+    // Load contract addresses
+    const nzDollarAddress = ""; // Add the deployed NZDollar address here
+    const vaultAddress = ""; // Add the deployed BanknoteCollateralVault address here
+
+    if (!nzDollarAddress || !vaultAddress) {
+      throw new Error("Contract addresses not set");
+    }
+
+    const NZDollar = await ethers.getContractFactory("NZDollar");
+    const nzDollar = NZDollar.attach(nzDollarAddress);
+
+    const BanknoteCollateralVault = await ethers.getContractFactory("BanknoteCollateralVault");
+    const vault = BanknoteCollateralVault.attach(vaultAddress);
+
+    log("Contracts loaded successfully");
+
+    // Approve vault to spend NZDollar
+    const approveAmount = ethers.utils.parseEther("1000");
+    const approveTx = await nzDollar.approve(vaultAddress, approveAmount);
+    await approveTx.wait();
+    log(`Approved vault to spend ${ethers.utils.formatEther(approveAmount)} NZDollar`);
+
+    // Mint a banknote
+    const denomination = 100;
+    const secret = ethers.utils.randomBytes(32);
+    const hashedSecret = ethers.utils.keccak256(secret);
+    const mintTx = await vault.mintBanknote(nzDollarAddress, hashedSecret, denomination);
+    const mintReceipt = await mintTx.wait();
+    const banknoteId = mintReceipt.events.find(e => e.event === 'banknoteMinted').args.id;
+    log(`Minted banknote with ID ${banknoteId}, denomination ${denomination}, transaction hash: ${mintReceipt.transactionHash}`);
+
+    // Get banknote info
+    const banknoteInfo = await vault.getBanknoteInfo(banknoteId);
+    log(`Banknote info: Minter: ${banknoteInfo[0]}, HashedSecret: ${banknoteInfo[1]}, ERC20: ${banknoteInfo[2]}, Denomination: ${banknoteInfo[3]}`);
+
+    // Redeem partial amount of the banknote
+    const redeemAmount = ethers.utils.parseEther("50");
+    const discount = ethers.utils.parseEther("1");
+    const hash2 = ethers.utils.keccak256(ethers.utils.defaultAbiCoder.encode(["bytes32", "address"], [hashedSecret, addr1.address]));
+    
+    const redeemTx = await vault.connect(addr1).redeemBanknote(banknoteId, redeemAmount, hash2, discount);
+    const redeemReceipt = await redeemTx.wait();
+    log(`Redeemed ${ethers.utils.formatEther(redeemAmount)} from banknote ${banknoteId}, transaction hash: ${redeemReceipt.transactionHash}`);
+
+    // Check surplus funds
+    const surplusFunds = await vault.getSurplus(signer.address, nzDollarAddress);
+    log(`Surplus funds for signer: ${ethers.utils.formatEther(surplusFunds)} NZDollar`);
+
+    // Skim surplus funds
+    if (surplusFunds.gt(0)) {
+      const skimTx = await vault.skimSurplus(nzDollarAddress, surplusFunds);
+      const skimReceipt = await skimTx.wait();
+      log(`Skimmed ${ethers.utils.formatEther(surplusFunds)} NZDollar, transaction hash: ${skimReceipt.transactionHash}`);
+    } else {
+      log("No surplus funds to skim");
+    }
+
+    // Final balance check
+    const finalBalance = await nzDollar.balanceOf(signer.address);
+    log(`Final NZDollar balance of signer: ${ethers.utils.formatEther(finalBalance)}`);
+
+  } catch (error) {
+    log(`Error: ${error.message}`);
+    if (error.reason) log(`Reason: ${error.reason}`);
+    if (error.code) log(`Code: ${error.code}`);
+    if (error.transaction) log(`Transaction: ${JSON.stringify(error.transaction)}`);
+    process.exit(1);
+  }
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    log(`Unhandled Error: ${error.message}`);
+    process.exit(1);
+  });

--- a/contracts/scripts/test-connection.js
+++ b/contracts/scripts/test-connection.js
@@ -1,0 +1,22 @@
+const { Client, AccountBalanceQuery } = require("@hashgraph/sdk");
+require('dotenv').config();
+
+async function main() {
+  const myAccountId = process.env.HEDERA_ACCOUNT_ID;
+  const myPrivateKey = process.env.HEDERA_PRIVATE_KEY;
+
+  if (!myAccountId || !myPrivateKey) {
+    throw new Error("Environment variables HEDERA_ACCOUNT_ID and HEDERA_PRIVATE_KEY must be present");
+  }
+
+  const client = Client.forTestnet();
+  client.setOperator(myAccountId, myPrivateKey);
+
+  const balance = await new AccountBalanceQuery()
+    .setAccountId(myAccountId)
+    .execute(client);
+
+  console.log(`My account balance is: ${balance.hbars} HBAR`);
+}
+
+main();


### PR DESCRIPTION
Added deploy script and interact script. 

Hedera does indeed support smart contracts through the Hedera Smart Contract Service. 

To view your contract on the Hedera Testnet explorer:
https://hashscan.io/testnet

Test Hedera Connection:
`node test-connection.js`

Compile the contracts:
`npx hardhat compile`

Run the tests:
`npx hardhat test`

Deploy the contracts to Hedera testnet:
`npx hardhat run scripts/deploy.js --network hedera`

Interact with the deployed contracts:
`npx hardhat run scripts/interact.js --network hedera`

Replace the placeholder contract addresses (nzDollarAddress and vaultAddress) with your actual deployed contract addresses.